### PR TITLE
feat: add right-click menu to move folders between PARA categories

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -147,6 +147,8 @@ const EN = {
   TOPBANNER_LIFEOS_PRO_HREF: 'https://lifeos.vip/plugin/life-os-pro.html',
   TOP_BANNER_DEEPASK_AD: 'Inject AI Intelligence into LifeOS',
   TOP_BANNER_DEEPASK_HREF: 'https://lifeos.vip/plugin/deepask/deepask.html',
+
+  MOVE_TO: 'Move to',
 };
 
 const ZH = {
@@ -276,6 +278,8 @@ const ZH = {
   TOPBANNER_LIFEOS_PRO_HREF: 'https://lifeos.vip/zh/plugin/life-os-pro.html',
   TOP_BANNER_DEEPASK_AD: '为 LifeOS 注入 AI 智能',
   TOP_BANNER_DEEPASK_HREF: 'https://lifeos.vip/zh/plugin/deepask/deepask.html',
+
+  MOVE_TO: '移动到',
 };
 
 const I18N_MAP: Record<string, Record<string, string>> = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import { Platform, Plugin, setIcon } from 'obsidian';
-import type { App, MarkdownPostProcessorContext, PluginManifest, WorkspaceLeaf } from 'obsidian';
+import { Platform, Plugin, TFile, setIcon } from 'obsidian';
+import type { App, MarkdownPostProcessorContext, Menu, PluginManifest, TAbstractFile, WorkspaceLeaf } from 'obsidian';
 import { type DataviewApi, getAPI, isPluginEnabled } from 'obsidian-dataview';
 
 import enUS from 'antd/locale/en_US';
@@ -127,8 +127,45 @@ export default class LifeOS extends Plugin {
       return;
     }
     this.loadDailyRecord();
+    this.registerFileMenu();
     this.addSettingTab(new SettingTabView(this.app, this.settings, this, localeMap[locale]));
   }
+  registerFileMenu() {
+    if (!this.settings.usePARANotes) return;
+
+    const i18n = getI18n(locale);
+
+    this.registerEvent(
+      this.app.workspace.on('file-menu', (menu: Menu, file: TAbstractFile) => {
+        if (file instanceof TFile) return;
+
+        const paraFolders = [
+          this.settings.projectsPath,
+          this.settings.areasPath,
+          this.settings.resourcesPath,
+          this.settings.archivesPath,
+        ];
+
+        const parentPath = file.parent?.path;
+        if (!parentPath || !paraFolders.includes(parentPath)) return;
+
+        const targetFolders = paraFolders.filter((f) => f !== parentPath);
+
+        targetFolders.forEach((targetFolder) => {
+          menu.addItem((item) => {
+            item
+              .setSection('lifeos')
+              .setIcon('folder-tree')
+              .setTitle(`${i18n.MOVE_TO} "${targetFolder}"`)
+              .onClick(() => {
+                this.app.fileManager.renameFile(file, `${targetFolder}/${file.name}`);
+              });
+          });
+        });
+      }),
+    );
+  }
+
   loadDailyRecord() {
     if (this.settings.usePeriodicNotes && this.settings.useDailyRecord) {
       this.dailyRecord = new DailyRecord(this.app, this.settings, this.file, locale);

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,12 +131,11 @@ export default class LifeOS extends Plugin {
     this.addSettingTab(new SettingTabView(this.app, this.settings, this, localeMap[locale]));
   }
   registerFileMenu() {
-    if (!this.settings.usePARANotes) return;
-
     const i18n = getI18n(locale);
 
     this.registerEvent(
       this.app.workspace.on('file-menu', (menu: Menu, file: TAbstractFile) => {
+        if (!this.settings.usePARANotes) return;
         if (file instanceof TFile) return;
 
         const paraFolders = [


### PR DESCRIPTION
## Summary

Closes #59

- Adds right-click context menu for folders that are direct children of PARA directories (Projects, Areas, Resources, Archives)
- Menu shows "Move to" options for the other three PARA categories
- Uses `app.fileManager.renameFile` to move the entire folder

## Changes

- `src/main.ts`: New `registerFileMenu()` method that listens to `file-menu` events
- `src/i18n.ts`: Added `MOVE_TO` translation key (EN/ZH)

## Test plan

- [ ] Right-click a folder under Projects → see "Move to Areas/Resources/Archives"
- [ ] Click "Move to Archives" → folder moves to Archives directory
- [ ] Right-clicking a file (not folder) shows no extra menu items
- [ ] Right-clicking a folder NOT under PARA directories shows no extra menu items
- [ ] Disable PARA Notes in settings → no menu items appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>