### PR TITLE
feat: add BulletRecordListByTime view for periodic notes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -164,6 +164,7 @@ export default class LifeOS extends Plugin {
       AreaListByTime: this.area.listByTime,
       TaskRecordListByTime: this.task.recordListByTime,
       TaskDoneListByTime: this.task.doneListByTime,
+      BulletListByTime: this.bullet.listByTime,
       // views by tag -> topic context -> para
       TaskListByTag: this.task.listByTag,
       BulletListByTag: this.bullet.listByTag,

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,7 +164,7 @@ export default class LifeOS extends Plugin {
       AreaListByTime: this.area.listByTime,
       TaskRecordListByTime: this.task.recordListByTime,
       TaskDoneListByTime: this.task.doneListByTime,
-      BulletListByTime: this.bullet.listByTime,
+      BulletRecordListByTime: this.bullet.listByTime,
       // views by tag -> topic context -> para
       TaskListByTag: this.task.listByTag,
       BulletListByTag: this.bullet.listByTag,

--- a/src/periodic/Bullet.ts
+++ b/src/periodic/Bullet.ts
@@ -7,6 +7,7 @@ import { Markdown } from '../component/Markdown';
 import { ERROR_MESSAGE } from '../constant';
 import { getI18n } from '../i18n';
 import type LifeOS from '../main';
+import { Date as PeriodicDate } from '../periodic/Date';
 import { File } from '../periodic/File';
 import { generateIgnoreOperator, renderError } from '../util';
 
@@ -14,6 +15,7 @@ type Element = { text: string; link: Link };
 
 export class Bullet {
   app: App;
+  date: PeriodicDate;
   file: File;
   plugin: LifeOS;
   settings: PluginSettings;
@@ -24,7 +26,49 @@ export class Bullet {
     this.plugin = plugin;
     this.locale = locale;
     this.file = new File(this.app, this.settings, this.plugin, locale);
+    this.date = new PeriodicDate(this.app, this.settings, this.file, locale);
   }
+
+  listByTime = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    const filename = ctx.sourcePath;
+    const parsed = this.date.parse(filename);
+    const condition = this.date.days(parsed);
+
+    if (!condition.from || !condition.to) {
+      return;
+    }
+
+    const dataview = await this.plugin.getDataviewAPI();
+
+    // 收集日期范围内的文件
+    const files = this.date.files(parsed);
+    const { days, weeks, months, quarters } = files;
+    const pages = [...days, ...weeks, ...months, ...quarters];
+
+    if (!pages.length) {
+      return;
+    }
+
+    const lists = dataview
+      .pages(`"${pages.join('" or "')}"`)
+      .file.lists.where((L: { task: boolean; path: string }) => {
+        return !L.task && L.path !== filename;
+      });
+
+    const groupResult = lists.groupBy((elem: Element) => {
+      return elem.link;
+    });
+    const sortResult = groupResult.sort((elem: { rows: Element }) => elem.rows.link, 'desc');
+    const tableResult = sortResult.map((k: { rows: Element }) => [k.rows.text as string, k.rows.link as Link]);
+    const tableValues = tableResult.array();
+
+    const div = el.createEl('div');
+    const component = new Markdown(div);
+
+    dataview.table(['Bullet', 'Link'], tableValues, div, component, filename);
+
+    ctx.addChild(component);
+  };
 
   listByTag = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
     const filepath = ctx.sourcePath;

--- a/src/periodic/Bullet.ts
+++ b/src/periodic/Bullet.ts
@@ -48,13 +48,13 @@ export class Bullet {
       return;
     }
 
-    const habitHeader = this.settings.habitHeader?.trim();
+    const dailyRecordHeader = this.settings.dailyRecordHeader?.trim();
     const lists = dataview
       .pages(`"${days.join('" or "')}"`)
       .file.lists.where((L: { task: boolean; path: string; section: { subpath?: string } }) => {
         if (L.task) return false;
-        // 排除习惯打卡区域的 bullet
-        if (habitHeader && L.section?.subpath?.trim() === habitHeader) return false;
+        // 只收集日常记录标题下的 bullet
+        if (dailyRecordHeader) return L.section?.subpath?.trim() === dailyRecordHeader;
         return true;
       })
       .sort((L: { path: string; line: number }) => L.path, 'desc');

--- a/src/periodic/Bullet.ts
+++ b/src/periodic/Bullet.ts
@@ -48,13 +48,13 @@ export class Bullet {
       return;
     }
 
-    const dailyRecordHeader = this.settings.dailyRecordHeader?.trim();
+    const habitHeader = this.settings.habitHeader?.trim();
     const lists = dataview
       .pages(`"${days.join('" or "')}"`)
       .file.lists.where((L: { task: boolean; path: string; section: { subpath?: string } }) => {
         if (L.task) return false;
-        // 只取 Daily Record 标题下的 bullet，与 pro 版保持一致
-        if (dailyRecordHeader && L.section?.subpath?.trim() !== dailyRecordHeader) return false;
+        // 排除习惯打卡区域的 bullet
+        if (habitHeader && L.section?.subpath?.trim() === habitHeader) return false;
         return true;
       })
       .sort((L: { path: string; line: number }) => L.path, 'desc');

--- a/src/periodic/Bullet.ts
+++ b/src/periodic/Bullet.ts
@@ -40,20 +40,24 @@ export class Bullet {
 
     const dataview = await this.plugin.getDataviewAPI();
 
-    // 收集日期范围内的文件
+    // 只收集日期范围内的日记文件
     const files = this.date.files(parsed);
-    const { days, weeks, months, quarters } = files;
-    const pages = [...days, ...weeks, ...months, ...quarters];
+    const { days } = files;
 
-    if (!pages.length) {
+    if (!days.length) {
       return;
     }
 
+    const dailyRecordHeader = this.settings.dailyRecordHeader?.trim();
     const lists = dataview
-      .pages(`"${pages.join('" or "')}"`)
-      .file.lists.where((L: { task: boolean; path: string }) => {
-        return !L.task && L.path !== filename;
-      });
+      .pages(`"${days.join('" or "')}"`)
+      .file.lists.where((L: { task: boolean; path: string; section: { subpath?: string } }) => {
+        if (L.task) return false;
+        // 只取 Daily Record 标题下的 bullet，与 pro 版保持一致
+        if (dailyRecordHeader && L.section?.subpath?.trim() !== dailyRecordHeader) return false;
+        return true;
+      })
+      .sort((L: { path: string; line: number }) => L.path, 'desc');
 
     const groupResult = lists.groupBy((elem: Element) => {
       return elem.link;


### PR DESCRIPTION
## Summary

Closes #94

- Adds `BulletRecordListByTime` view that can be used in weekly, monthly, quarterly and yearly notes
- Collects non-task bullet items from daily notes' Daily Record section within the date range, grouped by source file

## Changes

- `src/periodic/Bullet.ts`: New `listByTime` method following the same pattern as `Task.recordListByTime`, filtering by Daily Record header section
- `src/main.ts`: Register `BulletRecordListByTime` in the views map

## Usage

In a weekly/monthly/quarterly/yearly note template:

````markdown
```LifeOS
BulletRecordListByTime
```
````

## Test plan

- [ ] Add `BulletRecordListByTime` code block to a weekly note → shows bullets from that week's daily notes
- [ ] Add to monthly note → shows bullets from that month
- [ ] Add to quarterly/yearly note → aggregates correctly
- [ ] Tasks (checkbox items) are excluded, only plain bullets shown
- [ ] Only bullets under the Daily Record header are included
- [ ] Empty result when no bullets exist in the date range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>